### PR TITLE
Implicit parameters for Partitioning Columns

### DIFF
--- a/bmsdna/lakeapi/core/config.py
+++ b/bmsdna/lakeapi/core/config.py
@@ -26,6 +26,7 @@ from polars.type_aliases import JoinStrategy
 from bmsdna.lakeapi.core.env import CACHE_EXPIRATION_TIME_SECONDS
 
 from bmsdna.lakeapi.core.log import get_logger
+from bmsdna.lakeapi.core.partition_utils import _with_implicit_parameters
 from bmsdna.lakeapi.core.types import FileTypes, OperatorType, Param, PolaryTypeFunction, Engines, SearchConfig
 
 logger = get_logger(__name__)
@@ -131,25 +132,6 @@ class DatasourceConfig:
 @dataclass
 class Option:
     ...
-
-
-def _with_implicit_parameters(paramslist: List[Param], file_type: str, basic_config: BasicConfig, uri: str):
-    if file_type == "delta":
-        delta_uri = os.path.join(
-            basic_config.data_path,
-            uri,
-        )
-        from deltalake import DeltaTable
-
-        part_cols = DeltaTable(delta_uri).metadata().partition_columns
-        if part_cols and len(part_cols) > 0:
-            all_names = [(p.colname or p.name).lower() for p in paramslist]
-            new_params = list(paramslist)
-            for pc in part_cols:
-                if pc.lower() not in all_names:
-                    new_params.append(Param(pc, operators=["="], colname=pc))
-            return new_params
-    return paramslist
 
 
 @dataclass

--- a/bmsdna/lakeapi/core/dataframe.py
+++ b/bmsdna/lakeapi/core/dataframe.py
@@ -24,7 +24,7 @@ from aiocache.serializers import PickleSerializer
 from bmsdna.lakeapi.core.config import BasicConfig, DatasourceConfig, GroupByConfig, GroupByExpConfig, Param
 from bmsdna.lakeapi.core.env import CACHE_EXPIRATION_TIME_SECONDS
 from bmsdna.lakeapi.core.log import get_logger
-from bmsdna.lakeapi.core.model import get_param_def, should_hide_colname
+from bmsdna.lakeapi.core.model import get_param_def
 from bmsdna.lakeapi.core.types import DeltaOperatorTypes, FileTypes
 from bmsdna.lakeapi.context.df_base import ResultData, ExecutionContext
 import pypika

--- a/bmsdna/lakeapi/core/endpoint.py
+++ b/bmsdna/lakeapi/core/endpoint.py
@@ -31,11 +31,8 @@ from bmsdna.lakeapi.core.dataframe import (
     filter_partitions_based_on_params,
 )
 from bmsdna.lakeapi.core.log import get_logger
-from bmsdna.lakeapi.core.model import (
-    create_parameter_model,
-    create_response_model,
-    should_hide_colname,
-)
+from bmsdna.lakeapi.core.model import create_parameter_model, create_response_model
+from bmsdna.lakeapi.core.partition_utils import should_hide_colname
 from bmsdna.lakeapi.core.response import create_response
 from bmsdna.lakeapi.core.types import (
     MetadataDetailResult,

--- a/bmsdna/lakeapi/core/model.py
+++ b/bmsdna/lakeapi/core/model.py
@@ -7,6 +7,7 @@ from fastapi import Query
 from pydantic import BaseModel, create_model
 from bmsdna.lakeapi.context.df_base import ResultData
 from bmsdna.lakeapi.core.config import Param, SearchConfig
+from bmsdna.lakeapi.core.partition_utils import should_hide_colname
 from bmsdna.lakeapi.core.types import OperatorType
 from bmsdna.lakeapi.core.env import CACHE_EXPIRATION_TIME_SECONDS
 import pyarrow as pa
@@ -167,10 +168,6 @@ def create_parameter_model(
 class TypeBaseModel(BaseModel):
     class Config:
         orm_mode = True
-
-
-def should_hide_colname(name: str):
-    return name.startswith("_") or "_md5_prefix_" in name or "_xxhash64_prefix_" in name or "_md5_mod_" in name
 
 
 def create_response_model(name: str, frame: ResultData) -> type[BaseModel]:

--- a/bmsdna/lakeapi/core/partition_utils.py
+++ b/bmsdna/lakeapi/core/partition_utils.py
@@ -1,16 +1,16 @@
-from typing import List
+from typing import List, TYPE_CHECKING
 import os
 
-from bmsdna.lakeapi.core.config import BasicConfig
-
-from bmsdna.lakeapi.core.types import Param
+if TYPE_CHECKING:
+    from bmsdna.lakeapi.core.config import BasicConfig
+    from bmsdna.lakeapi.core.types import Param
 
 
 def should_hide_colname(name: str):
     return name.startswith("_") or "_md5_prefix_" in name or "_xxhash64_prefix_" in name or "_md5_mod_" in name
 
 
-def _with_implicit_parameters(paramslist: List[Param], file_type: str, basic_config: BasicConfig, uri: str):
+def _with_implicit_parameters(paramslist: "List[Param]", file_type: str, basic_config: "BasicConfig", uri: str):
     if file_type == "delta":
         delta_uri = os.path.join(
             basic_config.data_path,

--- a/bmsdna/lakeapi/core/partition_utils.py
+++ b/bmsdna/lakeapi/core/partition_utils.py
@@ -24,6 +24,8 @@ def _with_implicit_parameters(paramslist: "List[Param]", file_type: str, basic_c
             new_params = list(paramslist)
             for pc in part_cols:
                 if pc.lower() not in all_names and not should_hide_colname(pc):
+                    from bmsdna.lakeapi.core.types import Param
+
                     new_params.append(Param(pc, operators=["="], colname=pc))
             return new_params
     return paramslist

--- a/bmsdna/lakeapi/core/partition_utils.py
+++ b/bmsdna/lakeapi/core/partition_utils.py
@@ -1,0 +1,29 @@
+from typing import List
+import os
+
+from bmsdna.lakeapi.core.config import BasicConfig
+
+from bmsdna.lakeapi.core.types import Param
+
+
+def should_hide_colname(name: str):
+    return name.startswith("_") or "_md5_prefix_" in name or "_xxhash64_prefix_" in name or "_md5_mod_" in name
+
+
+def _with_implicit_parameters(paramslist: List[Param], file_type: str, basic_config: BasicConfig, uri: str):
+    if file_type == "delta":
+        delta_uri = os.path.join(
+            basic_config.data_path,
+            uri,
+        )
+        from deltalake import DeltaTable
+
+        part_cols = DeltaTable(delta_uri).metadata().partition_columns
+        if part_cols and len(part_cols) > 0:
+            all_names = [(p.colname or p.name).lower() for p in paramslist]
+            new_params = list(paramslist)
+            for pc in part_cols:
+                if pc.lower() not in all_names and not should_hide_colname(pc):
+                    new_params.append(Param(pc, operators=["="], colname=pc))
+            return new_params
+    return paramslist

--- a/bmsdna/lakeapi/core/response.py
+++ b/bmsdna/lakeapi/core/response.py
@@ -124,22 +124,17 @@ DisableRedirections=False"""
     elif format == OutputFormats.SEMI_CSV:
         content.write_csv(out, separator=";")
     elif format == OutputFormats.CSV4EXCEL:  # need to write sep=, on first line
-        if isinstance(out, str):
-            content.write_csv(out + "_u8", separator=",")  # type: ignore
-            with open(
-                out, mode="wb"
-            ) as f:  # excel wants utf-16le which polars does not support. therefore we need reencoding
-                f.write(b"sep=,\n")  # add utf-8 bom at beginning
-                with open(out + "_u8", mode="r", encoding="utf-8") as c8:
+        content.write_csv(out + "_u8", separator=",")  # type: ignore
+        with open(
+            out, mode="wb"
+        ) as f:  # excel wants utf-16le which polars does not support. therefore we need reencoding
+            f.write(b"sep=,\n")  # add utf-8 bom at beginning
+            with open(out + "_u8", mode="r", encoding="utf-8") as c8:
+                line = c8.readline()
+                while line != "":
+                    f.write(line.encode("utf-16le"))
                     line = c8.readline()
-                    while line != "":
-                        f.write(line.encode("utf-16le"))
-                        line = c8.readline()
-                os.remove(out + "_u8")
-
-        else:
-            out.write(b"sep=,\r\n")  # not used, and would break special characters
-            content.write_csv(out, separator=",")
+            os.remove(out + "_u8")
     elif format == OutputFormats.XLSX:
         import polars as pl
 

--- a/config_test.yml
+++ b/config_test.yml
@@ -42,10 +42,6 @@ tables:
       - get
       - post
     params:
-      - name: cars
-        operators:
-          - "="
-          - in
       - name: fruits
         operators:
           - "="
@@ -72,12 +68,14 @@ tables:
     version: 1
     api_method:
       - get
+      - post
     datasource:
       uri: delta/fruits_partition_mod
     params:
       - name: cars
         operators:
           - "="
+          - "in"
 
   - name: fruits_nested
     tag: test

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -388,7 +388,21 @@ def test_data_partition_mod():
     for e in engines:
         response = client.get(
             f"/api/v1/test/fruits_partition_mod?limit=1&format=json&cars=audi&%24engine={e}",
+            auth=auth,  # works because of implicit parameters
+        )
+        assert response.status_code == 200
+        assert response.json() == [
+            {
+                "A": 2,
+                "fruits": "banana",
+                "B": 4,
+                "cars": "audi",
+            }
+        ]
+        response = client.post(
+            f"/api/v1/test/fruits_partition_mod?limit=1&format=json&%24engine={e}",
             auth=auth,
+            json={"cars_in": ["audi"]},
         )
         assert response.status_code == 200
         assert response.json() == [


### PR DESCRIPTION
You no longer have to configure params if you're table is partitioned. Does not auto add filters for non-user visible cols such as _md5_prefix