### PR TITLE
more generic sql endpoint

### DIFF
--- a/bmsdna/lakeapi/core/config.py
+++ b/bmsdna/lakeapi/core/config.py
@@ -17,6 +17,7 @@ from typing import (
     TypedDict,
     Union,
     cast,
+    TYPE_CHECKING,
 )
 from typing_extensions import TypedDict, NotRequired, Required
 from fastapi import APIRouter, Request
@@ -29,6 +30,8 @@ from bmsdna.lakeapi.core.log import get_logger
 from bmsdna.lakeapi.core.partition_utils import _with_implicit_parameters
 from bmsdna.lakeapi.core.types import FileTypes, OperatorType, Param, PolaryTypeFunction, Engines, SearchConfig
 
+if TYPE_CHECKING:
+    from bmsdna.lakeapi.context.df_base import ExecutionContext
 logger = get_logger(__name__)
 
 
@@ -39,6 +42,7 @@ class BasicConfig:
     data_path: str
     min_search_length: int
     default_engine: Engines
+    prepare_sql_db_hook: "Callable[[ExecutionContext], Any] | None"
 
 
 def get_default_config():
@@ -48,6 +52,7 @@ def get_default_config():
         data_path=os.environ.get("DATA_PATH", "data"),
         min_search_length=3,
         default_engine="duckdb",
+        prepare_sql_db_hook=None,
     )
 
 

--- a/bmsdna/lakeapi/core/dataframe.py
+++ b/bmsdna/lakeapi/core/dataframe.py
@@ -40,14 +40,6 @@ endpoints = Literal["query", "meta", "request", "sql"]
 cache = cached(ttl=CACHE_EXPIRATION_TIME_SECONDS, cache=Cache.MEMORY, serializer=PickleSerializer())
 
 
-def get_table_name_from_uri(uri: str):
-    parts = uri.split("/")
-    try:
-        return parts[-2].replace(".", "_") + "_" + parts[-1].replace(".", "_")
-    except IndexError:
-        return uri
-
-
 class Dataframe:
     def __init__(
         self,
@@ -94,7 +86,7 @@ class Dataframe:
 
             df = df.select(
                 Star(
-                    table=pypika.Table(get_table_name_from_uri(self.config.uri)),
+                    table=pypika.Table(self.tablename),
                 )
             )
         return df
@@ -108,7 +100,9 @@ class Dataframe:
 
     @property
     def tablename(self):
-        return self.version + "_" + self.tag + "_" + self.name + "_" + get_table_name_from_uri(self.config.uri)
+        if self.version  in ["1", "v1"]:
+            return self.tag + "_" + self.name
+        return self.tag + "_" + self.name + "_" + self.version
 
     def get_df(
         self,

--- a/bmsdna/lakeapi/core/route.py
+++ b/bmsdna/lakeapi/core/route.py
@@ -21,8 +21,8 @@ def init_routes(configs: Configs, basic_config: BasicConfig):
         get_response_model,
         create_detailed_meta_endpoint,
         create_config_endpoint,
-        create_sql_endpoint,
     )
+    from bmsdna.lakeapi.core.sql_endpoint import create_sql_endpoint
 
     all_lake_api_routers.append((basic_config, configs))
     router = APIRouter()

--- a/bmsdna/lakeapi/core/sql_endpoint.py
+++ b/bmsdna/lakeapi/core/sql_endpoint.py
@@ -1,0 +1,99 @@
+from typing import Any, Optional, Callable, Union
+import duckdb
+from fastapi import APIRouter, BackgroundTasks, Header, Request
+from bmsdna.lakeapi.context.df_base import ExecutionContext
+from bmsdna.lakeapi.core.config import BasicConfig, Config, Configs, Param, SearchConfig
+from bmsdna.lakeapi.context.df_duckdb import DuckDbExecutionContextBase
+from bmsdna.lakeapi.core.dataframe import Dataframe
+from bmsdna.lakeapi.core.types import OutputFileType
+from bmsdna.lakeapi.core.response import create_response
+
+duckcon: Optional[duckdb.DuckDBPyConnection] = None
+
+
+def init_duck_con(con: DuckDbExecutionContextBase, basic_config: BasicConfig, configs: Configs):
+    for cfg in configs:
+        df = Dataframe(cfg.version_str, cfg.tag, cfg.name, cfg.datasource, con, basic_config)
+        con.register_dataframe(df.tablename, df.uri, df.config.file_type, None)
+
+
+def get_duckdb_con(basic_config: BasicConfig, configs: Configs):
+    global duckcon
+    if duckcon is None:
+        duckcon = duckdb.connect()
+        context = DuckDbExecutionContextBase(duckcon)
+        init_duck_con(context, basic_config, configs)
+        if basic_config.prepare_sql_db_hook is not None:
+            basic_config.prepare_sql_db_hook(context)
+
+    else:
+        context = DuckDbExecutionContextBase(duckcon)
+    return context
+
+
+def create_sql_endpoint(
+    router: APIRouter,
+    basic_config: BasicConfig,
+    configs: Configs,
+):
+    @router.on_event("shutdown")
+    async def shutdown_event():
+        global duckcon
+        if duckcon is not None:
+            duckcon.close()
+
+    @router.get("/api/sql/tables", tags=["sql"], operation_id="get_sql_tables")
+    async def get_sql_tables(
+        request: Request,
+        background_tasks: BackgroundTasks,
+        Accept: Union[str, None] = Header(default=None),
+        format: Optional[OutputFileType] = "json",
+    ):
+        con = get_duckdb_con(basic_config, configs)
+        return (
+            con.execute_sql("SELECT table_name, table_type from information_schema.tables where schema_name='main'")
+            .to_arrow_table()
+            .to_pylist()
+        )
+
+    @router.post(
+        "/api/sql",
+        tags=["sql"],
+        operation_id="post_sql_endpoint",
+    )
+    async def get_sql_post(
+        request: Request,
+        background_tasks: BackgroundTasks,
+        Accept: Union[str, None] = Header(default=None),
+        format: Optional[OutputFileType] = "json",
+    ):
+        body = await request.body()
+        from bmsdna.lakeapi.context.df_duckdb import DuckDbExecutionContextBase
+
+        con = get_duckdb_con(basic_config, configs)
+        df = con.execute_sql(body.decode("utf-8"))
+
+        return await create_response(
+            request.url, format or request.headers["Accept"], df, con, basic_config=basic_config
+        )
+
+    @router.get(
+        "/api/sql",
+        tags=["sql"],
+        operation_id="get_sql_endpoint",
+    )
+    async def get_sql_get(
+        request: Request,
+        background_tasks: BackgroundTasks,
+        sql: str,
+        Accept: Union[str, None] = Header(default=None),
+        format: Optional[OutputFileType] = "json",
+    ):
+        from bmsdna.lakeapi.context.df_duckdb import DuckDbExecutionContextBase
+
+        con = get_duckdb_con(basic_config, configs)
+
+        df = con.execute_sql(sql)
+        return await create_response(
+            request.url, format or request.headers["Accept"], df, con, basic_config=basic_config
+        )

--- a/bmsdna/lakeapi/core/sql_endpoint.py
+++ b/bmsdna/lakeapi/core/sql_endpoint.py
@@ -14,7 +14,8 @@ duckcon: Optional[duckdb.DuckDBPyConnection] = None
 def init_duck_con(con: DuckDbExecutionContextBase, basic_config: BasicConfig, configs: Configs):
     for cfg in configs:
         df = Dataframe(cfg.version_str, cfg.tag, cfg.name, cfg.datasource, con, basic_config)
-        con.register_dataframe(df.tablename, df.uri, df.config.file_type, None)
+        if df.file_exists():
+            con.register_dataframe(df.tablename, df.uri, df.config.file_type, None)
 
 
 def get_duckdb_con(basic_config: BasicConfig, configs: Configs):
@@ -51,7 +52,7 @@ def create_sql_endpoint(
     ):
         con = get_duckdb_con(basic_config, configs)
         return (
-            con.execute_sql("SELECT table_name, table_type from information_schema.tables where schema_name='main'")
+            con.execute_sql("SELECT table_name, table_type from information_schema.tables where table_schema='main'")
             .to_arrow_table()
             .to_pylist()
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bmsdna-lakeapi"
-version = "0.5.2"
+version = "0.6.0"
 description = ""
 authors = ["DWH Team <you@example.com>"]
 license = "MIT"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -435,58 +435,6 @@ def test_data_partition_mod():
         ]
 
 
-def test_sql_endoint_post():
-    # better naming needed in the future
-
-    query = """select * 
-        from delta_fruits 
-        where cars = 'audi' 
-        and fruits = 'banana' 
-        and A = 2 and B = 4"""
-
-    response = client.post(
-        f"/api/sql",
-        auth=auth,
-        data=cast(RequestData, query),
-    )
-    assert response.status_code == 200
-    print(response.json())
-    assert response.json() == [
-        {
-            "A": 2,
-            "fruits": "banana",
-            "B": 4,
-            "cars": "audi",
-        }
-    ]
-
-
-def test_sql_endoint_get():
-    # better naming needed in the future
-
-    query = """select * 
-        from delta_fruits 
-        where cars = 'audi' 
-        and fruits = 'banana' 
-        and A = 2 and B = 4"""
-
-    response = client.get(
-        f"/api/sql",
-        auth=auth,
-        params={"sql": query},
-    )
-    assert response.status_code == 200
-    print(response.json())
-    assert response.json() == [
-        {
-            "A": 2,
-            "fruits": "banana",
-            "B": 4,
-            "cars": "audi",
-        }
-    ]
-
-
 def test_fruits_nested():
     for e in engines:
         response = client.get(f"/api/v1/test/fruits_nested?limit=2&format=json&%24engine={e}", auth=auth)

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -29,8 +29,60 @@ def test_post():
     response = client.post(
         f"/api/sql",
         auth=auth,
-        data="SELECT distinct B FROM complexer_complex_fruits union select distinct A FROM startest_fruits",
+        data="SELECT distinct B FROM complexer_complex_fruits union select distinct A FROM startest_fruits",  # type: ignore
     )
     assert response.status_code == 200
     tables = response.json()
     assert len(tables) > 5
+
+
+def test_sql_where_post():
+    # better naming needed in the future
+
+    query = """select * 
+        from test_fruits 
+        where cars = 'audi' 
+        and fruits = 'banana' 
+        and A = 2 and B = 4"""
+
+    response = client.post(
+        f"/api/sql",
+        auth=auth,
+        data=query,  # type: ignore
+    )
+    assert response.status_code == 200
+    print(response.json())
+    assert response.json() == [
+        {
+            "A": 2,
+            "fruits": "banana",
+            "B": 4,
+            "cars": "audi",
+        }
+    ]
+
+
+def test_sql_where_get():
+    # better naming needed in the future
+
+    query = """select * 
+        from test_fruits 
+        where cars = 'audi' 
+        and fruits = 'banana' 
+        and A = 2 and B = 4"""
+
+    response = client.get(
+        f"/api/sql",
+        auth=auth,
+        params={"sql": query},
+    )
+    assert response.status_code == 200
+    print(response.json())
+    assert response.json() == [
+        {
+            "A": 2,
+            "fruits": "banana",
+            "B": 4,
+            "cars": "audi",
+        }
+    ]

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,0 +1,36 @@
+from fastapi.testclient import TestClient
+from .utils import get_app, get_auth
+
+client = TestClient(get_app())
+auth = get_auth()
+
+
+def test_tables():
+    response = client.get(
+        f"/api/sql/tables",
+        auth=auth,
+    )
+    assert response.status_code == 200
+    tables = response.json()
+    assert len(tables) > 5
+
+
+def test_get():
+    response = client.get(
+        f"/api/sql?sql=SELECT distinct B FROM complexer_complex_fruits union select distinct A FROM startest_fruits",
+        auth=auth,
+    )
+    assert response.status_code == 200
+    tables = response.json()
+    assert len(tables) > 5
+
+
+def test_post():
+    response = client.post(
+        f"/api/sql",
+        auth=auth,
+        data="SELECT distinct B FROM complexer_complex_fruits union select distinct A FROM startest_fruits",
+    )
+    assert response.status_code == 200
+    tables = response.json()
+    assert len(tables) > 5


### PR DESCRIPTION
By default, just expose tables in config.
Allow to do more fancy stuff in a hook in basic_config 